### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Replace `-p phpdbg` with `-p php` in the Makefile coverage target so this repository follows the org-wide coverage runner migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps the starter skeleton aligned with the shared direction and avoids new repositories inheriting the old runner.

## Changes

- switch the `coverage` target in `Makefile` from `phpdbg` to `php`
- keep the rest of the tester coverage command unchanged

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification attempted: `make coverage`
- Local `make coverage` currently fails in this environment because `php` has no Xdebug or PCOV extension loaded, and coverage with `-p php` requires one of those drivers.